### PR TITLE
Add UPID-backed job rehydration for #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ Completeness and escape hatches:
 
 Some tools now publish large text or binary outputs as MCP artifact resources instead of forcing everything inline into a single JSON response. Those artifacts are exposed under `proxmox://artifacts/{artifactId}`.
 
+Job durability boundary:
+
+- UPID-backed work is rehydratable through `job_get`, `job_wait`, `job_cancel`, and `job_logs` because Proxmox persists the underlying task
+- typical examples are VM lifecycle/config mutations, storage download-url jobs, backups, and other typed REST mutations that return a Proxmox UPID
+- process-run execution paths such as `proxmox_cli_run`, `proxmox_shell_run`, `proxmox_node_terminal_run`, and `proxmox_vm_guest_exec` remain process-local when deferred
+- this server does not create its own durable local job database; cross-session durability is only provided where Proxmox already owns it
+
 The validated boot/bootstrap findings behind the new VM diagnostics tools are tracked in [boot-and-bootstrap.md](./docs/proxmox/boot-and-bootstrap.md).
 
 ## Configuration

--- a/docs/direct-mcp-testing.md
+++ b/docs/direct-mcp-testing.md
@@ -127,6 +127,14 @@ When validating a module, the preferred proof is:
 - read back the resulting state through MCP
 - record any gaps found in the module/tool surface
 
+## Deferred Job Boundary
+
+Deferred jobs are not uniformly durable.
+
+- UPID-backed tool calls can be resumed later through `job_get`, `job_wait`, `job_cancel`, and `job_logs`
+- process-run execution paths such as `proxmox_cli_run`, `proxmox_shell_run`, `proxmox_node_terminal_run`, and `proxmox_vm_guest_exec` remain tied to the current live server process
+- this repo does not create its own local durable job database; cross-session durability is only available where Proxmox already owns the underlying task
+
 ## Rules For Workarounds During Testing
 
 For Proxmox-related actions under module development:

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -1,6 +1,15 @@
 import type { ArtifactRef, ServerJob, TargetRef } from "./types.js";
 import { makeId, nowIso } from "./utils.js";
 
+const UPID_JOB_PREFIX = "proxmox_upid_job_";
+
+export interface UpidJobHandlePayload {
+  v: 1;
+  operation: string;
+  target: TargetRef;
+  upid: string;
+}
+
 /** Error shape for jobs that fail after producing partial diagnostic output. */
 export class JobExecutionError extends Error {
   constructor(message: string, readonly result?: unknown) {
@@ -18,6 +27,52 @@ export interface JobContext {
   setArtifacts: (artifacts: ArtifactRef[]) => void;
 }
 
+/** Encodes a rehydratable job id for tasks that Proxmox already persists by UPID. */
+export function makeUpidJobId(target: TargetRef, operation: string, upid: string): string {
+  const payload: UpidJobHandlePayload = {
+    v: 1,
+    operation,
+    target,
+    upid,
+  };
+  return `${UPID_JOB_PREFIX}${Buffer.from(JSON.stringify(payload), "utf8").toString("base64url")}`;
+}
+
+/** Parses a rehydratable UPID-backed job id into its structured payload. */
+export function parseUpidJobId(jobId: string): UpidJobHandlePayload | null {
+  if (!jobId.startsWith(UPID_JOB_PREFIX)) {
+    return null;
+  }
+
+  const encoded = jobId.slice(UPID_JOB_PREFIX.length);
+  if (!encoded) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")) as Partial<UpidJobHandlePayload>;
+    if (
+      parsed?.v !== 1
+      || typeof parsed.operation !== "string"
+      || !parsed.target
+      || typeof parsed.target.cluster !== "string"
+      || typeof parsed.target.kind !== "string"
+      || typeof parsed.upid !== "string"
+    ) {
+      return null;
+    }
+
+    return {
+      v: 1,
+      operation: parsed.operation,
+      target: parsed.target,
+      upid: parsed.upid,
+    };
+  } catch {
+    return null;
+  }
+}
+
 /**
  * In-memory job registry for long-running MCP work.
  *
@@ -31,8 +86,15 @@ export class JobManager {
   private readonly completions = new Map<string, Promise<ServerJob>>();
 
   /** Creates the initial pending record before execution starts. */
-  create(target: TargetRef, operation: string): ServerJob {
-    const jobId = makeId("job");
+  create(
+    target: TargetRef,
+    operation: string,
+    options: {
+      jobId?: string;
+      relatedUpid?: string;
+    } = {},
+  ): ServerJob {
+    const jobId = options.jobId ?? makeId("job");
     const snapshot: ServerJob = {
       jobId,
       target,
@@ -42,15 +104,37 @@ export class JobManager {
       updatedAt: nowIso(),
       logsAvailable: false,
       logs: [],
+      ...(options.relatedUpid
+        ? {
+            relatedUpid: options.relatedUpid,
+            resultRef: {
+              type: "proxmox_upid" as const,
+              value: options.relatedUpid,
+            },
+          }
+        : {}),
     };
 
     this.jobs.set(jobId, snapshot);
     return snapshot;
   }
 
+  /** Creates a job whose identity can be reconstructed later from its Proxmox UPID. */
+  createUpidJob(target: TargetRef, operation: string, upid: string): ServerJob {
+    return this.create(target, operation, {
+      jobId: makeUpidJobId(target, operation, upid),
+      relatedUpid: upid,
+    });
+  }
+
+  /** Returns the in-memory snapshot when present. */
+  find(jobId: string): ServerJob | undefined {
+    return this.jobs.get(jobId);
+  }
+
   /** Returns the current job snapshot or throws for an unknown job id. */
   get(jobId: string): ServerJob {
-    const job = this.jobs.get(jobId);
+    const job = this.find(jobId);
     if (!job) {
       throw new Error(`Unknown job '${jobId}'`);
     }

--- a/src/mcp-common.ts
+++ b/src/mcp-common.ts
@@ -88,6 +88,7 @@ export function jobHandleResult(job: ServerJob, note?: string) {
     operation: job.operation,
     target: job.target,
     relatedUpid: job.relatedUpid,
+    durability: job.relatedUpid ? "proxmox_upid" : "process_local",
   });
 }
 
@@ -99,6 +100,7 @@ export function completedJobResult(job: ServerJob, note?: string) {
     operation: job.operation,
     target: job.target,
     relatedUpid: job.relatedUpid,
+    durability: job.relatedUpid ? "proxmox_upid" : "process_local",
     result: job.result,
     error: job.error,
     logs: job.logs.slice(-200),

--- a/src/tools/escape/README.md
+++ b/src/tools/escape/README.md
@@ -28,3 +28,9 @@ Transport preference:
 Validation boundary:
 - these tools exist to cover validated gaps and completeness
 - do not treat them as a substitute for adding generic typed domain primitives when a reusable Proxmox action is missing
+
+Job durability boundary:
+- UPID-backed jobs can be re-read later through `job_*` because Proxmox persists the underlying task
+- `proxmox_api_call` benefits from that only when the called endpoint actually returns a UPID
+- `proxmox_cli_run` and `proxmox_shell_run` remain break-glass execution paths, so deferred job handles for them are process-local
+- this tool does not add its own durable local job store

--- a/src/tools/escape/register.ts
+++ b/src/tools/escape/register.ts
@@ -2,7 +2,114 @@ import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { ServerContext } from "../../mcp-common.js";
 import { artifactResult, commonExecutionSchema, completedJobResult, emitProgress, jobHandleResult, settleJob, textResult } from "../../mcp-common.js";
-import { CAPABILITY_NAMES, type TargetRef } from "../../types.js";
+import { parseUpidJobId } from "../../jobs.js";
+import { CAPABILITY_NAMES, type JobState, type ServerJob, type TargetRef } from "../../types.js";
+import { nowIso, sleep } from "../../utils.js";
+
+function upidNode(upid: string): string {
+  const node = upid.split(":")[1];
+  if (!node) {
+    throw new Error(`Invalid UPID '${upid}'`);
+  }
+  return node;
+}
+
+function upidStartedAt(upid: string): string {
+  const startHex = upid.split(":")[4];
+  if (!startHex) {
+    return nowIso();
+  }
+
+  const seconds = Number.parseInt(startHex, 16);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return nowIso();
+  }
+
+  return new Date(seconds * 1000).toISOString();
+}
+
+function normalizeTaskLogs(log: unknown): string[] {
+  if (!Array.isArray(log)) {
+    return [];
+  }
+
+  return log.map((entry) => {
+    if (typeof entry === "string") {
+      return entry;
+    }
+
+    if (entry && typeof entry === "object" && typeof (entry as { t?: unknown }).t === "string") {
+      return (entry as { t: string }).t;
+    }
+
+    return JSON.stringify(entry);
+  });
+}
+
+function classifyUpidState(status: unknown): { state: JobState; error?: string } {
+  const record = status && typeof status === "object" ? status as Record<string, unknown> : {};
+  if (record.status !== "stopped") {
+    return { state: "running" };
+  }
+
+  const exitStatus = typeof record.exitstatus === "string" ? record.exitstatus.trim() : "";
+  if (!exitStatus || exitStatus.toUpperCase() === "OK") {
+    return { state: "completed" };
+  }
+
+  if (/(abort|cancel|interrupt)/i.test(exitStatus)) {
+    return { state: "cancelled", error: exitStatus };
+  }
+
+  return { state: "failed", error: exitStatus };
+}
+
+async function readUpidJobSnapshot(context: ServerContext, jobId: string): Promise<ServerJob> {
+  const handle = parseUpidJobId(jobId);
+  if (!handle) {
+    throw new Error(`Unknown job '${jobId}'`);
+  }
+
+  const node = upidNode(handle.upid);
+  const status = await context.service.getTaskStatus(handle.target.cluster, node, handle.upid);
+  const log = await context.service.getTaskLog(handle.target.cluster, node, handle.upid);
+  const logs = normalizeTaskLogs(log);
+  const classified = classifyUpidState(status);
+
+  return {
+    jobId,
+    target: handle.target,
+    operation: handle.operation,
+    state: classified.state,
+    startedAt: upidStartedAt(handle.upid),
+    updatedAt: nowIso(),
+    logsAvailable: logs.length > 0,
+    logs,
+    resultRef: { type: "proxmox_upid", value: handle.upid },
+    relatedUpid: handle.upid,
+    result: {
+      status,
+      log,
+    },
+    ...(classified.error ? { error: classified.error } : {}),
+  };
+}
+
+async function waitForUpidJobSnapshot(context: ServerContext, jobId: string, timeoutMs?: number, signal?: AbortSignal): Promise<ServerJob> {
+  const started = Date.now();
+  while (true) {
+    const snapshot = await readUpidJobSnapshot(context, jobId);
+    if (snapshot.state !== "running") {
+      return snapshot;
+    }
+
+    if (timeoutMs !== undefined && Date.now() - started >= timeoutMs) {
+      return snapshot;
+    }
+
+    await sleep(1_000, signal);
+  }
+}
 
 /** Registers generic REST/CLI/shell escape hatches plus MCP resources, prompts, and job tools. */
 export function registerEscapeTools(context: ServerContext) {
@@ -40,13 +147,14 @@ export function registerEscapeTools(context: ServerContext) {
   server.registerResource(
     "job-log-resource",
     new ResourceTemplate("proxmox://jobs/{jobId}/logs", { list: undefined }),
-    { title: "Job Logs", description: "In-memory logs for background jobs created by this server.", mimeType: "text/plain" },
+    { title: "Job Logs", description: "Logs for a background job. UPID-backed jobs can be re-read from Proxmox across server restarts; process-run jobs are local to the current server.", mimeType: "text/plain" },
     async (uri, params) => {
       const jobId = Array.isArray(params.jobId) ? params.jobId[0] : params.jobId;
       if (!jobId) {
         throw new Error("Missing jobId parameter");
       }
-      const logs = jobManager.listLogs(jobId);
+      const localJob = jobManager.find(jobId);
+      const logs = localJob ? localJob.logs : (await readUpidJobSnapshot(context, jobId)).logs;
       return { contents: [{ uri: uri.href, mimeType: "text/plain", text: logs.join("") }] };
     },
   );
@@ -85,7 +193,7 @@ export function registerEscapeTools(context: ServerContext) {
   server.registerTool(
     "proxmox_api_call",
     {
-      description: "Call any documented Proxmox API endpoint by HTTP method and path. This is the completeness escape hatch for REST coverage.",
+      description: "Call any documented Proxmox API endpoint by HTTP method and path. This is the completeness escape hatch for REST coverage. When Proxmox returns a UPID task, deferred job follow-up can be resumed later through `job_*`.",
       inputSchema: { cluster: clusterSchema, method: z.enum(["GET", "POST", "PUT", "DELETE"]), path: z.string().min(1), args: z.record(z.string(), z.unknown()).default({}), ...commonExecutionSchema },
     },
     async ({ cluster, method, path, args, waitMode, timeoutMs, pollIntervalMs }, extra) => {
@@ -94,8 +202,7 @@ export function registerEscapeTools(context: ServerContext) {
       if (!result.upid) {
         return textResult(`API ${method} ${path}`, result.data);
       }
-      const job = jobManager.create(target, `api:${method}:${path}`);
-      job.relatedUpid = result.upid;
+      const job = jobManager.createUpidJob(target, `api:${method}:${path}`, result.upid);
       jobManager.run(job.jobId, async (jobContext) => {
         jobContext.setRelatedUpid(result.upid!);
         return service.waitForUpid(cluster, result.upid!, pollIntervalMs ?? 2_000, jobContext.signal, async (progress) => {
@@ -111,7 +218,7 @@ export function registerEscapeTools(context: ServerContext) {
   server.registerTool(
     "proxmox_cli_run",
     {
-      description: "Run an allowed Proxmox CLI family command over SSH on a Proxmox node.",
+      description: "Run an allowed Proxmox CLI family command over SSH on a Proxmox node. Deferred jobs for this break-glass path are process-local to the current server.",
       inputSchema: {
         cluster: clusterSchema,
         node: z.string().min(1),
@@ -138,7 +245,7 @@ export function registerEscapeTools(context: ServerContext) {
   server.registerTool(
     "proxmox_shell_run",
     {
-      description: "Run a policy-gated shell command against a node or guest transport.",
+      description: "Run a policy-gated shell command against a node or guest transport. Deferred jobs for this break-glass path are process-local to the current server.",
       inputSchema: {
         cluster: clusterSchema,
         targetKind: targetKindSchema,
@@ -220,36 +327,65 @@ export function registerEscapeTools(context: ServerContext) {
     },
   );
 
-  server.registerTool("job_get", { description: "Get the current state of a background job managed by this server.", inputSchema: { jobId: z.string().min(1) } }, async ({ jobId }) =>
-    completedJobResult(jobManager.get(jobId), `Job ${jobId}`),
+  server.registerTool(
+    "job_get",
+    {
+      description: "Get the current state of a background job. UPID-backed jobs can be re-read from Proxmox across server sessions; process-run jobs require the same live server instance.",
+      inputSchema: { jobId: z.string().min(1) },
+    },
+    async ({ jobId }) => {
+      const localJob = jobManager.find(jobId);
+      return completedJobResult(localJob ?? await readUpidJobSnapshot(context, jobId), `Job ${jobId}`);
+    },
   );
 
   server.registerTool(
     "job_wait",
-    { description: "Wait for a background job to finish or return its current state after a timeout.", inputSchema: { jobId: z.string().min(1), timeoutMs: z.number().int().positive().optional() } },
-    async ({ jobId, timeoutMs }) => completedJobResult(await jobManager.wait(jobId, timeoutMs), `Job ${jobId}`),
+    {
+      description: "Wait for a background job to finish or return its current state after a timeout. UPID-backed jobs can be resumed across server sessions; process-run jobs cannot.",
+      inputSchema: { jobId: z.string().min(1), timeoutMs: z.number().int().positive().optional() },
+    },
+    async ({ jobId, timeoutMs }, extra) => {
+      const localJob = jobManager.find(jobId);
+      const settled = localJob ? await jobManager.wait(jobId, timeoutMs) : await waitForUpidJobSnapshot(context, jobId, timeoutMs, extra.signal);
+      return completedJobResult(settled, `Job ${jobId}`);
+    },
   );
 
   server.registerTool(
     "job_cancel",
-    { description: "Cancel a background job. Proxmox UPID tasks are cancelled when the API supports it.", inputSchema: { jobId: z.string().min(1) } },
+    {
+      description: "Cancel a background job. UPID-backed jobs request cancellation through Proxmox and remain rehydratable later; process-run jobs are cancelled only inside the current server process.",
+      inputSchema: { jobId: z.string().min(1) },
+    },
     async ({ jobId }) => {
-      const job = jobManager.get(jobId);
-      if (job.relatedUpid) {
+      const localJob = jobManager.find(jobId);
+      const rehydratable = parseUpidJobId(jobId);
+      if (localJob?.relatedUpid || rehydratable) {
+        const handle = rehydratable ?? { upid: localJob!.relatedUpid!, target: localJob!.target, operation: localJob!.operation, v: 1 as const };
         try {
-          await service.cancelUpid(job.target.cluster, job.relatedUpid);
+          await service.cancelUpid(handle.target.cluster, handle.upid);
         } catch {
           // Best effort.
         }
+        return completedJobResult(await readUpidJobSnapshot(context, jobId), `Cancellation requested for ${jobId}`);
       }
+
       return completedJobResult(await jobManager.cancel(jobId), `Job ${jobId} cancelled`);
     },
   );
 
   server.registerTool(
     "job_logs",
-    { description: "Read recent logs for a background job.", inputSchema: { jobId: z.string().min(1), limit: z.number().int().positive().default(200) } },
-    async ({ jobId, limit }) => textResult(`Logs for ${jobId}`, { jobId, logs: jobManager.listLogs(jobId, limit) }),
+    {
+      description: "Read recent logs for a background job. UPID-backed jobs are read from Proxmox task logs; process-run jobs return only current-server in-memory logs.",
+      inputSchema: { jobId: z.string().min(1), limit: z.number().int().positive().default(200) },
+    },
+    async ({ jobId, limit }) => {
+      const localJob = jobManager.find(jobId);
+      const logs = localJob ? localJob.logs.slice(-limit) : (await readUpidJobSnapshot(context, jobId)).logs.slice(-limit);
+      return textResult(`Logs for ${jobId}`, { jobId, logs });
+    },
   );
 
   server.registerTool(

--- a/src/tools/infrastructure/register.ts
+++ b/src/tools/infrastructure/register.ts
@@ -89,8 +89,7 @@ export function registerInfrastructureTools(context: ServerContext) {
         return textResult(`Backup started on ${node}`, result.data);
       }
 
-      const job = jobManager.create(target, "backup:start");
-      job.relatedUpid = result.upid;
+      const job = jobManager.createUpidJob(target, "backup:start", result.upid);
       jobManager.run(job.jobId, async (jobContext) => {
         jobContext.setRelatedUpid(result.upid!);
         return service.waitForUpid(cluster, result.upid!, pollIntervalMs ?? 2_000, jobContext.signal, async (progress) => {

--- a/src/tools/lxc/register.ts
+++ b/src/tools/lxc/register.ts
@@ -36,8 +36,7 @@ export function registerLxcTools(context: ServerContext) {
       if (!response.upid) {
         return textResult(`LXC action ${action} completed`, response.data);
       }
-      const job = jobManager.create(target, `lxc:${action}`);
-      job.relatedUpid = response.upid;
+      const job = jobManager.createUpidJob(target, `lxc:${action}`, response.upid);
       jobManager.run(job.jobId, async (jobContext) => {
         jobContext.setRelatedUpid(response.upid!);
         return service.waitForUpid(cluster, response.upid!, pollIntervalMs ?? 2_000, jobContext.signal, async (progress) => {

--- a/src/tools/node/register.ts
+++ b/src/tools/node/register.ts
@@ -49,8 +49,7 @@ export function registerNodeTools(context: ServerContext) {
         return textResult(`Node action ${action} completed`, response.data);
       }
 
-      const job = jobManager.create(target, `node:${action}`);
-      job.relatedUpid = response.upid;
+      const job = jobManager.createUpidJob(target, `node:${action}`, response.upid);
       jobManager.run(job.jobId, async (jobContext) => {
         jobContext.setRelatedUpid(response.upid!);
         return service.waitForUpid(cluster, response.upid!, pollIntervalMs ?? 2_000, jobContext.signal, async (progress) => {
@@ -79,7 +78,7 @@ export function registerNodeTools(context: ServerContext) {
   server.registerTool(
     "proxmox_node_terminal_run",
     {
-      description: "Run a stateless shell command on a Proxmox node and wait for completion or a background job handle.",
+      description: "Run a stateless shell command on a Proxmox node and wait for completion or a background job handle. Deferred jobs for this break-glass path are process-local to the current server.",
       inputSchema: {
         cluster: clusterSchema,
         node: z.string().min(1).describe("Proxmox node name."),

--- a/src/tools/qemu/README.md
+++ b/src/tools/qemu/README.md
@@ -34,6 +34,10 @@ Transport preference:
 - guest execution prefers guest-agent-capable paths and falls back to validated guest transport only when necessary
 - diagnostics may aggregate several low-level signals when that makes guest boot and guest-agent failures easier to isolate
 
+Job durability boundary:
+- UPID-backed VM lifecycle and config mutations can be followed later through `job_*`
+- `proxmox_vm_guest_exec` remains process-local when deferred because the server, not Proxmox, owns that execution path
+
 Validation boundary:
 - keep these tools as low-level VM primitives
 - allow bounded diagnostics tools that aggregate closely related VM signals, as long as their sources and fallbacks stay explicit

--- a/src/tools/qemu/register.ts
+++ b/src/tools/qemu/register.ts
@@ -104,8 +104,7 @@ export function registerQemuTools(context: ServerContext) {
         return textResult(`VM action ${action} completed`, response.data);
       }
 
-      const job = jobManager.create(target, `vm:${action}`);
-      job.relatedUpid = response.upid;
+      const job = jobManager.createUpidJob(target, `vm:${action}`, response.upid);
       jobManager.run(job.jobId, async (jobContext) => {
         jobContext.setRelatedUpid(response.upid!);
         return service.waitForUpid(cluster, response.upid!, pollIntervalMs ?? 2_000, jobContext.signal, async (progress) => {
@@ -124,7 +123,7 @@ export function registerQemuTools(context: ServerContext) {
   server.registerTool(
     "proxmox_vm_guest_exec",
     {
-      description: "Execute a command inside a QEMU VM using the guest agent or configured guest transport.",
+      description: "Execute a command inside a QEMU VM using the guest agent or configured guest transport. Deferred jobs for this execution path are process-local to the current server.",
       inputSchema: {
         cluster: clusterSchema,
         vmid: vmidSchema,
@@ -187,8 +186,7 @@ export function registerQemuTools(context: ServerContext) {
       if (!response.upid) {
         return textResult(`VM ${vmid} created`, response.data);
       }
-      const job = jobManager.create(target, "vm:create");
-      job.relatedUpid = response.upid;
+      const job = jobManager.createUpidJob(target, "vm:create", response.upid);
       jobManager.run(job.jobId, async (jobContext) => {
         jobContext.setRelatedUpid(response.upid!);
         return service.waitForUpid(cluster, response.upid!, pollIntervalMs ?? 2_000, jobContext.signal, async (progress) => {
@@ -220,8 +218,7 @@ export function registerQemuTools(context: ServerContext) {
       if (!response.upid) {
         return textResult(`VM ${vmid} config updated`, response.data);
       }
-      const job = jobManager.create(target, "vm:update_config");
-      job.relatedUpid = response.upid;
+      const job = jobManager.createUpidJob(target, "vm:update_config", response.upid);
       jobManager.run(job.jobId, async (jobContext) => {
         jobContext.setRelatedUpid(response.upid!);
         return service.waitForUpid(cluster, response.upid!, pollIntervalMs ?? 2_000, jobContext.signal, async (progress) => {
@@ -280,8 +277,7 @@ export function registerQemuTools(context: ServerContext) {
         return textResult(`VM ${vmid} PCI slot ${slot} attached`, { ...response, config: latest.config });
       }
 
-      const job = jobManager.create(target, "vm:pci_attach");
-      job.relatedUpid = response.upid;
+      const job = jobManager.createUpidJob(target, "vm:pci_attach", response.upid);
       jobManager.run(job.jobId, async (jobContext) => {
         jobContext.setRelatedUpid(response.upid!);
         const task = await service.waitForUpid(cluster, response.upid!, pollIntervalMs ?? 2_000, jobContext.signal, async (progress) => {
@@ -319,8 +315,7 @@ export function registerQemuTools(context: ServerContext) {
         return textResult(`VM ${vmid} PCI slot ${slot} detached`, { ...response, config: latest.config });
       }
 
-      const job = jobManager.create(target, "vm:pci_detach");
-      job.relatedUpid = response.upid;
+      const job = jobManager.createUpidJob(target, "vm:pci_detach", response.upid);
       jobManager.run(job.jobId, async (jobContext) => {
         jobContext.setRelatedUpid(response.upid!);
         const task = await service.waitForUpid(cluster, response.upid!, pollIntervalMs ?? 2_000, jobContext.signal, async (progress) => {
@@ -355,8 +350,7 @@ export function registerQemuTools(context: ServerContext) {
       if (!response.upid) {
         return textResult(`VM ${vmid} converted to template`, response.data);
       }
-      const job = jobManager.create(target, "vm:convert_to_template");
-      job.relatedUpid = response.upid;
+      const job = jobManager.createUpidJob(target, "vm:convert_to_template", response.upid);
       jobManager.run(job.jobId, async (jobContext) => {
         jobContext.setRelatedUpid(response.upid!);
         return service.waitForUpid(cluster, response.upid!, pollIntervalMs ?? 2_000, jobContext.signal, async (progress) => {
@@ -397,8 +391,7 @@ export function registerQemuTools(context: ServerContext) {
       if (!response.upid) {
         return textResult(`VM ${vmid} cloned to ${newid}`, response.data);
       }
-      const job = jobManager.create(targetRef, "vm:clone");
-      job.relatedUpid = response.upid;
+      const job = jobManager.createUpidJob(targetRef, "vm:clone", response.upid);
       jobManager.run(job.jobId, async (jobContext) => {
         jobContext.setRelatedUpid(response.upid!);
         return service.waitForUpid(cluster, response.upid!, pollIntervalMs ?? 2_000, jobContext.signal, async (progress) => {
@@ -443,8 +436,7 @@ export function registerQemuTools(context: ServerContext) {
       if (!response.upid) {
         return textResult(`VM ${vmid} destroyed`, response.data);
       }
-      const job = jobManager.create(target, "vm:destroy");
-      job.relatedUpid = response.upid;
+      const job = jobManager.createUpidJob(target, "vm:destroy", response.upid);
       jobManager.run(job.jobId, async (jobContext) => {
         jobContext.setRelatedUpid(response.upid!);
         return service.waitForUpid(cluster, response.upid!, pollIntervalMs ?? 2_000, jobContext.signal, async (progress) => {

--- a/src/tools/storage/register.ts
+++ b/src/tools/storage/register.ts
@@ -51,8 +51,7 @@ export function registerStorageTools(context: ServerContext) {
         return textResult(`Storage download to ${storage} completed`, response.data);
       }
 
-      const job = jobManager.create(target, "storage:download_url");
-      job.relatedUpid = response.upid;
+      const job = jobManager.createUpidJob(target, "storage:download_url", response.upid);
       jobManager.run(job.jobId, async (jobContext) => {
         jobContext.setRelatedUpid(response.upid!);
         return service.waitForUpid(cluster, response.upid!, pollIntervalMs ?? 2_000, jobContext.signal, async (progress) => {

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { JobManager, makeUpidJobId, parseUpidJobId } from "../src/jobs.js";
+
+describe("UPID-backed job handles", () => {
+  it("round-trips a rehydratable job id", () => {
+    const jobId = makeUpidJobId(
+      { cluster: "lab", kind: "qemu_vm", vmid: 100 },
+      "vm:start",
+      "UPID:pve01:00000001:00000002:67E89B80:qmstart:100:root@pam:",
+    );
+
+    expect(parseUpidJobId(jobId)).toEqual({
+      v: 1,
+      operation: "vm:start",
+      target: { cluster: "lab", kind: "qemu_vm", vmid: 100 },
+      upid: "UPID:pve01:00000001:00000002:67E89B80:qmstart:100:root@pam:",
+    });
+  });
+
+  it("returns null for non-UPID job ids", () => {
+    expect(parseUpidJobId("job_123")).toBeNull();
+    expect(parseUpidJobId("proxmox_upid_job_not-json")).toBeNull();
+  });
+
+  it("creates an in-memory job snapshot whose id can be rehydrated later from the UPID", () => {
+    const manager = new JobManager();
+    const job = manager.createUpidJob(
+      { cluster: "lab", kind: "node", node: "pve01" },
+      "backup:start",
+      "UPID:pve01:00000001:00000002:67E89B80:vzdump::root@pam:",
+    );
+
+    expect(job.relatedUpid).toBe("UPID:pve01:00000001:00000002:67E89B80:vzdump::root@pam:");
+    expect(job.resultRef).toEqual({
+      type: "proxmox_upid",
+      value: "UPID:pve01:00000001:00000002:67E89B80:vzdump::root@pam:",
+    });
+    expect(parseUpidJobId(job.jobId)).toEqual({
+      v: 1,
+      operation: "backup:start",
+      target: { cluster: "lab", kind: "node", node: "pve01" },
+      upid: "UPID:pve01:00000001:00000002:67E89B80:vzdump::root@pam:",
+    });
+  });
+});

--- a/tests/mcp-common.test.ts
+++ b/tests/mcp-common.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { textResult } from "../src/mcp-common.js";
+import { completedJobResult, jobHandleResult, textResult } from "../src/mcp-common.js";
 
 describe("textResult", () => {
   it("keeps object payloads as structured content", () => {
@@ -18,5 +18,43 @@ describe("textResult", () => {
     const result = textResult("Scalar result", "ok");
 
     expect(result.structuredContent).toEqual({ data: "ok" });
+  });
+
+  it("includes durability metadata in job handle results", () => {
+    const result = jobHandleResult({
+      jobId: "job_123",
+      target: { cluster: "lab", kind: "node", node: "pve01" },
+      operation: "shell_run",
+      state: "running",
+      startedAt: "2026-03-30T00:00:00.000Z",
+      updatedAt: "2026-03-30T00:00:00.000Z",
+      logsAvailable: false,
+      logs: [],
+    });
+
+    expect(result.structuredContent).toMatchObject({
+      jobId: "job_123",
+      durability: "process_local",
+    });
+  });
+
+  it("includes UPID durability metadata in completed job results", () => {
+    const result = completedJobResult({
+      jobId: "proxmox_upid_job_x",
+      target: { cluster: "lab", kind: "qemu_vm", vmid: 100 },
+      operation: "vm:start",
+      state: "completed",
+      startedAt: "2026-03-30T00:00:00.000Z",
+      updatedAt: "2026-03-30T00:00:01.000Z",
+      logsAvailable: true,
+      logs: ["started"],
+      relatedUpid: "UPID:pve01:00000001:00000002:67E89B80:qmstart:100:root@pam:",
+      result: { ok: true },
+    });
+
+    expect(result.structuredContent).toMatchObject({
+      relatedUpid: "UPID:pve01:00000001:00000002:67E89B80:qmstart:100:root@pam:",
+      durability: "proxmox_upid",
+    });
   });
 });


### PR DESCRIPTION
Refs #12

Implements the durable-job fix with the narrower product boundary we want:

- UPID-backed jobs now use rehydratable job IDs that can be resolved later from Proxmox task state and logs
- `job_get`, `job_wait`, `job_cancel`, `job_logs`, and `proxmox://jobs/{jobId}/logs` now fall back to Proxmox for those UPID-backed job handles even after the original MCP server process is gone
- break-glass execution paths stay process-local when deferred:
  - `proxmox_cli_run`
  - `proxmox_shell_run`
  - `proxmox_node_terminal_run`
  - `proxmox_vm_guest_exec`
- no local durable job database or temporary state directory was added

Why this shape:

- it fixes the main product problem for typed Proxmox-task-backed work
- it keeps the escape hatches explicitly non-durable instead of quietly turning them into a supported background execution platform
- it preserves the drop-in stdio model without new persistent runtime config

Docs were updated to spell out the durability boundary.

Validation:
- `npm run check`
- `npm run test`
- `npm run build`