### PR TITLE
Document closing issues on main promotion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,5 +48,9 @@ When opening a PR:
 
 - target `dev` for normal work
 - target `main` only for release promotions from `dev` or urgent `hotfix/*` work
+- when work is tracked by a GitHub issue, keep that work in a dedicated issue-owned branch and PR
+- prefer branch names that keep the issue association obvious, for example `feature/issue-13-pci-passthrough`
+- use `Refs #<issue>` while the work is still in `dev` or under review so the issue stays open during integration
+- close the issue when the change is actually promoted to `main`, either manually or through the `main` promotion PR if you intentionally want GitHub to auto-close it at that point
 - summarize operator-visible behavior changes clearly
 - call out any high-risk shell, file, or mutation-path changes explicitly

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -17,12 +17,20 @@ For normal changes:
 
 1. branch from `dev`
 2. develop in a short-lived `feature/*` branch
-3. open a PR into `dev`
-4. let CI pass on `dev`
-5. merge into `dev`
-6. promote `dev` to `main` only when the integrated state is fully tested and ready for production
+3. if the work is tracked by a GitHub issue, keep that issue's implementation in its own dedicated branch and PR
+4. open a PR into `dev`
+5. link the PR back to the issue with `Refs #<issue>` so the issue stays open while the change is still only in `dev`
+6. let CI pass on `dev`
+7. merge into `dev`
+8. promote `dev` to `main` only when the integrated state is fully tested and ready for production
 
 The intent is to keep `main` stable while still giving maintainers a shared integration branch for in-flight work.
+
+Issue handling rule:
+
+- treat the issue as open work until the change reaches `main`
+- merging into `dev` is integration, not final closure
+- close the issue when the relevant promotion to `main` lands, either manually or by using an auto-closing keyword on the `dev` -> `main` PR when that is what you want
 
 ## Release Promotion
 


### PR DESCRIPTION
Documents the maintainer workflow we settled on:

- issue work should stay in an issue-owned branch and PR while in progress
- use `Refs #<issue>` during feature work in `dev`
- keep the issue open while the change is only integrated in `dev`
- close the issue when the change actually reaches `main`

This is a docs-only workflow update and is intentionally separate from feature tickets.