### PR TITLE
Improve typed tool ergonomics for #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,73 @@ Job durability boundary:
 - process-run execution paths such as `proxmox_cli_run`, `proxmox_shell_run`, `proxmox_node_terminal_run`, and `proxmox_vm_guest_exec` remain process-local when deferred
 - this server does not create its own durable local job database; cross-session durability is only provided where Proxmox already owns it
 
+Common calling conventions:
+
+- `cluster` may be omitted only when the server has exactly one configured cluster; otherwise pass a configured alias such as `default`
+- `vmid` accepts either an integer like `100` or a digit-only string like `"100"`
+- `proxmox_vm_guest_exec.command`, `proxmox_shell_run.command`, and `proxmox_node_terminal_run.command` take one command string, not argv arrays
+- `proxmox_file_write` and `proxmox_cloud_init_snippet_put` expect exactly one content source: inline `content`, `artifactId`, or `resourceUri`
+
+Quick examples:
+
+```json
+{
+  "tool": "proxmox_inventory_overview",
+  "arguments": {
+    "probeRemote": false
+  }
+}
+```
+
+```json
+{
+  "tool": "proxmox_vm_get",
+  "arguments": {
+    "cluster": "default",
+    "vmid": "100"
+  }
+}
+```
+
+```json
+{
+  "tool": "proxmox_vm_guest_exec",
+  "arguments": {
+    "cluster": "default",
+    "vmid": 100,
+    "command": "uname -a",
+    "interpreter": "bash",
+    "waitMode": "wait"
+  }
+}
+```
+
+```json
+{
+  "tool": "proxmox_shell_run",
+  "arguments": {
+    "cluster": "default",
+    "targetKind": "node",
+    "node": "pve01",
+    "command": "qm list",
+    "interpreter": "bash"
+  }
+}
+```
+
+```json
+{
+  "tool": "proxmox_file_write",
+  "arguments": {
+    "cluster": "default",
+    "targetKind": "qemu_vm",
+    "vmid": 100,
+    "filePath": "/tmp/hello.txt",
+    "content": "hello from proxmox-mcp\n"
+  }
+}
+```
+
 The validated boot/bootstrap findings behind the new VM diagnostics tools are tracked in [boot-and-bootstrap.md](./docs/proxmox/boot-and-bootstrap.md).
 
 ## Configuration

--- a/docs/direct-mcp-testing.md
+++ b/docs/direct-mcp-testing.md
@@ -70,6 +70,12 @@ Do not rely on editor reload behavior as the main proof that a module works.
 
 ## Example: Direct MCP Read
 
+Calling-convention reminders before you test:
+
+- when the server has exactly one configured cluster, tool calls may omit `cluster`
+- `vmid` may be passed as `100` or `"100"`
+- guest and shell execution tools take a single `command` string plus an `interpreter`, not argv arrays
+
 This pattern queries the live server directly from the repo without adding the MCP server to an external agent handler:
 
 ```powershell
@@ -79,7 +85,6 @@ import { createLiveClient, callToolRecord } from "./tests/live/mcp-live-helpers.
 const client = await createLiveClient();
 try {
   const data = await callToolRecord(client, "proxmox_vm_list", {
-    cluster: "default",
   });
   console.log(JSON.stringify(data, null, 2));
 } finally {
@@ -106,13 +111,13 @@ import { createLiveClient, callToolRecord } from "./tests/live/mcp-live-helpers.
 
 const client = await createLiveClient();
 try {
-  const result = await callToolRecord(client, "proxmox_vm_action", {
+  const result = await callToolRecord(client, "proxmox_vm_guest_exec", {
     cluster: "default",
-    vmid: 94207,
-    action: "stop",
+    vmid: "94207",
+    command: "uname -a",
+    interpreter: "bash",
     waitMode: "wait",
     timeoutMs: 120000,
-    pollIntervalMs: 1000,
   });
   console.log(JSON.stringify(result, null, 2));
 } finally {

--- a/src/tool-inputs.ts
+++ b/src/tool-inputs.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+import type { RuntimeConfig } from "./config.js";
+
+function configuredClusterNames(config: RuntimeConfig): string[] {
+  return config.clusters.map((cluster) => cluster.name);
+}
+
+function clusterErrorMessage(config: RuntimeConfig): string {
+  const names = configuredClusterNames(config);
+  if (names.length === 1) {
+    return `\`cluster\` must be the configured cluster alias. Omit it only when the server has exactly one configured cluster; this server will then use \`${names[0]}\`.`;
+  }
+
+  if (names.length > 1) {
+    return `\`cluster\` must be one of the configured cluster aliases: ${names.map((name) => `\`${name}\``).join(", ")}.`;
+  }
+
+  return "`cluster` must be a configured cluster alias.";
+}
+
+function normalizeVmidInput(value: unknown): unknown {
+  if (typeof value === "string" && /^\d+$/.test(value.trim())) {
+    return Number.parseInt(value.trim(), 10);
+  }
+
+  return value;
+}
+
+export function createClusterSchema(config: RuntimeConfig) {
+  const names = configuredClusterNames(config);
+  const description =
+    names.length === 1
+      ? `Configured cluster alias. Omit this when exactly one cluster is configured; the server will use \`${names[0]}\`.`
+      : "Configured cluster alias.";
+  const base = z
+    .string({
+      error: () => clusterErrorMessage(config),
+    })
+    .trim()
+    .min(1, clusterErrorMessage(config))
+    .describe(description);
+
+  if (names.length === 1) {
+    return z.preprocess((value) => (value === undefined ? names[0] : typeof value === "string" ? value.trim() : value), base);
+  }
+
+  return z.preprocess((value) => (typeof value === "string" ? value.trim() : value), base);
+}
+
+export function createVmidSchema(description = "QEMU VM numeric ID.") {
+  const message = "`vmid` must be a positive integer or a digit-only string such as `100`.";
+  return z.preprocess(
+    normalizeVmidInput,
+    z
+      .number({
+        error: () => message,
+      })
+      .int(message)
+      .positive(message)
+      .describe(description),
+  );
+}
+
+export function createCommandStringSchema(description: string) {
+  const message =
+    "`command` must be a single command string. Use `interpreter` to select `bash`, `sh`, `powershell`, or `cmd`; do not pass argv arrays such as `[\"bash\", \"-lc\", \"uname -a\"]`.";
+  return z
+    .string({
+      error: () => message,
+    })
+    .min(1, message)
+    .describe(description);
+}

--- a/src/tools/access/register.ts
+++ b/src/tools/access/register.ts
@@ -1,11 +1,11 @@
-import { z } from "zod";
 import type { ServerContext } from "../../mcp-common.js";
 import { textResult } from "../../mcp-common.js";
+import { createClusterSchema } from "../../tool-inputs.js";
 
 /** Registers access and identity primitives. */
 export function registerAccessTools(context: ServerContext) {
   const { server, domains } = context;
-  const clusterSchema = z.string().describe("Configured cluster alias.");
+  const clusterSchema = createClusterSchema(context.config);
 
   // Uses: `/access/users`.
   server.registerTool(

--- a/src/tools/boot/register.ts
+++ b/src/tools/boot/register.ts
@@ -1,12 +1,13 @@
 import type { ServerContext } from "../../mcp-common.js";
 import { textResult } from "../../mcp-common.js";
 import { z } from "zod";
+import { createClusterSchema, createVmidSchema } from "../../tool-inputs.js";
 
 /** Registers VM boot diagnostics tools. */
 export function registerBootTools(context: ServerContext) {
   const { server, domains } = context;
-  const clusterSchema = z.string().describe("Configured cluster alias.");
-  const vmidSchema = z.number().int().positive().describe("QEMU VM numeric ID.");
+  const clusterSchema = createClusterSchema(context.config);
+  const vmidSchema = createVmidSchema("QEMU VM numeric ID.");
 
   /**
    * Uses:

--- a/src/tools/cluster/README.md
+++ b/src/tools/cluster/README.md
@@ -21,6 +21,10 @@ Transport preference:
 - REST first
 - no SSH fallback for the current tools in this folder
 
+Calling conventions:
+- when the server has exactly one configured cluster, the typed `cluster` input may be omitted and the server will use that sole configured alias
+- when multiple clusters are configured, callers should pass an explicit configured alias such as `default`
+
 Validation boundary:
 - keep these tools low-level and close to cluster resource semantics
 - do not add bundled operator workflows here

--- a/src/tools/cluster/register.ts
+++ b/src/tools/cluster/register.ts
@@ -2,18 +2,19 @@ import { z } from "zod";
 import type { ServerContext } from "../../mcp-common.js";
 import { textResult } from "../../mcp-common.js";
 import { commonExecutionSchema } from "../../mcp-common.js";
+import { createClusterSchema } from "../../tool-inputs.js";
 
 /** Registers cluster-scoped inventory and status primitives. */
 export function registerClusterTools(context: ServerContext) {
   const { server, domains } = context;
-  const clusterSchema = z.string().describe("Configured cluster alias.");
+  const clusterSchema = createClusterSchema(context.config);
   const pciMappingIdSchema = z.string().describe("Logical cluster-wide PCI mapping ID.");
 
   // Uses: `/cluster/resources`, `/cluster/status`, and `/version` through the cluster domain service.
   server.registerTool(
     "proxmox_inventory_overview",
     {
-      description: "Return cluster inventory and discovered capabilities for nodes, VMs, containers, and storages.",
+      description: "Return cluster inventory and discovered capabilities for nodes, VMs, containers, and storages. In a single-cluster setup, `cluster` may be omitted.",
       inputSchema: {
         cluster: clusterSchema,
         probeRemote: z.boolean().default(false).describe("Whether to probe for docker and remote shell reachability where possible."),
@@ -28,7 +29,7 @@ export function registerClusterTools(context: ServerContext) {
   server.registerTool(
     "proxmox_cluster_status",
     {
-      description: "Return cluster status and version information.",
+      description: "Return cluster status and version information for a configured cluster alias. In a single-cluster setup, `cluster` may be omitted.",
       inputSchema: { cluster: clusterSchema },
     },
     async ({ cluster }) => textResult(`Cluster status for ${cluster}`, await domains.cluster.getStatus(cluster)),

--- a/src/tools/escape/README.md
+++ b/src/tools/escape/README.md
@@ -34,3 +34,9 @@ Job durability boundary:
 - `proxmox_api_call` benefits from that only when the called endpoint actually returns a UPID
 - `proxmox_cli_run` and `proxmox_shell_run` remain break-glass execution paths, so deferred job handles for them are process-local
 - this tool does not add its own durable local job store
+
+Calling conventions:
+- `proxmox_shell_run.command` is a single command string, not an argv array
+- use `interpreter` to choose `sh`, `bash`, `powershell`, or `cmd`
+- `vmid` accepts either an integer like `100` or a digit-only string like `"100"`
+- `proxmox_file_write` expects exactly one content source: inline `content`, `artifactId`, or `resourceUri`

--- a/src/tools/escape/register.ts
+++ b/src/tools/escape/register.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { ServerContext } from "../../mcp-common.js";
 import { artifactResult, commonExecutionSchema, completedJobResult, emitProgress, jobHandleResult, settleJob, textResult } from "../../mcp-common.js";
 import { parseUpidJobId } from "../../jobs.js";
+import { createClusterSchema, createCommandStringSchema, createVmidSchema } from "../../tool-inputs.js";
 import { CAPABILITY_NAMES, type JobState, type ServerJob, type TargetRef } from "../../types.js";
 import { nowIso, sleep } from "../../utils.js";
 
@@ -114,8 +115,9 @@ async function waitForUpidJobSnapshot(context: ServerContext, jobId: string, tim
 /** Registers generic REST/CLI/shell escape hatches plus MCP resources, prompts, and job tools. */
 export function registerEscapeTools(context: ServerContext) {
   const { server, service, jobManager, artifacts } = context;
-  const clusterSchema = z.string().describe("Configured cluster alias.");
+  const clusterSchema = createClusterSchema(context.config);
   const targetKindSchema = z.enum(["node", "qemu_vm", "lxc_container", "linux_guest", "windows_guest"]);
+  const vmidSchema = createVmidSchema("QEMU VM or LXC CT numeric ID.");
 
   server.registerResource(
     "artifact-resource",
@@ -245,13 +247,13 @@ export function registerEscapeTools(context: ServerContext) {
   server.registerTool(
     "proxmox_shell_run",
     {
-      description: "Run a policy-gated shell command against a node or guest transport. Deferred jobs for this break-glass path are process-local to the current server.",
+      description: "Run a policy-gated shell command against a node or guest transport. `command` must be one shell string and `interpreter` chooses `sh`, `bash`, `powershell`, or `cmd`; do not pass argv arrays. Deferred jobs for this break-glass path are process-local to the current server.",
       inputSchema: {
         cluster: clusterSchema,
         targetKind: targetKindSchema,
         node: z.string().optional(),
-        vmid: z.number().int().positive().optional(),
-        command: z.string().min(1),
+        vmid: vmidSchema.optional(),
+        command: createCommandStringSchema("Single command string to run through the selected interpreter. Example: `command: \"uname -a\", interpreter: \"bash\"`."),
         interpreter: z.enum(["sh", "bash", "powershell", "cmd"]).default("sh"),
         useSudo: z.boolean().default(false),
         ...commonExecutionSchema,
@@ -284,7 +286,7 @@ export function registerEscapeTools(context: ServerContext) {
     "proxmox_file_read",
     {
       description: "Read a file through the best supported transport for the target.",
-      inputSchema: { cluster: clusterSchema, targetKind: targetKindSchema, node: z.string().optional(), vmid: z.number().int().positive().optional(), filePath: z.string().min(1) },
+      inputSchema: { cluster: clusterSchema, targetKind: targetKindSchema, node: z.string().optional(), vmid: vmidSchema.optional(), filePath: z.string().min(1) },
     },
     async ({ cluster, targetKind, node, vmid, filePath }) => {
       const target: TargetRef = { cluster, kind: targetKind, ...(node ? { node } : {}), ...(vmid !== undefined ? { vmid } : {}) };
@@ -302,12 +304,12 @@ export function registerEscapeTools(context: ServerContext) {
   server.registerTool(
     "proxmox_file_write",
     {
-      description: "Write a file through the best supported transport for the target.",
+      description: "Write a file through the best supported transport for the target. Provide exactly one content source: inline `content`, `artifactId`, or `resourceUri`.",
       inputSchema: {
         cluster: clusterSchema,
         targetKind: targetKindSchema,
         node: z.string().optional(),
-        vmid: z.number().int().positive().optional(),
+        vmid: vmidSchema.optional(),
         filePath: z.string().min(1),
         content: z.string().optional().describe("Inline UTF-8 file content for small text writes."),
         artifactId: z.string().optional().describe("Optional server artifact id to write instead of inline content."),
@@ -315,8 +317,9 @@ export function registerEscapeTools(context: ServerContext) {
       },
     },
     async ({ cluster, targetKind, node, vmid, filePath, content, artifactId, resourceUri }) => {
-      if (content === undefined && !artifactId && !resourceUri) {
-        throw new Error("File write requires content, artifactId, or resourceUri");
+      const providedSources = [content !== undefined, Boolean(artifactId), Boolean(resourceUri)].filter(Boolean).length;
+      if (providedSources !== 1) {
+        throw new Error("File write requires exactly one content source: inline content, artifactId, or resourceUri.");
       }
       const target: TargetRef = { cluster, kind: targetKind, ...(node ? { node } : {}), ...(vmid !== undefined ? { vmid } : {}) };
       if (artifactId || resourceUri) {

--- a/src/tools/infrastructure/register.ts
+++ b/src/tools/infrastructure/register.ts
@@ -2,12 +2,14 @@ import { z } from "zod";
 import type { ServerContext } from "../../mcp-common.js";
 import { commonExecutionSchema, completedJobResult, emitProgress, jobHandleResult, settleJob, textResult } from "../../mcp-common.js";
 import type { TargetRef } from "../../types.js";
+import { createClusterSchema, createVmidSchema } from "../../tool-inputs.js";
 
 /** Registers cross-cutting infrastructure primitives that do not yet justify narrower folders. */
 export function registerInfrastructureTools(context: ServerContext) {
   const { server, domains, service, jobManager } = context;
-  const clusterSchema = z.string().describe("Configured cluster alias.");
+  const clusterSchema = createClusterSchema(context.config);
   const nodeSchema = z.string().describe("Proxmox node name.");
+  const vmidSchema = createVmidSchema("QEMU VM or LXC CT numeric ID.");
 
   // Uses: cluster, node, QEMU, and LXC firewall endpoint families.
   server.registerTool(
@@ -18,7 +20,7 @@ export function registerInfrastructureTools(context: ServerContext) {
         cluster: clusterSchema,
         scope: z.enum(["cluster", "node", "qemu_vm", "lxc_container"]),
         node: z.string().optional(),
-        vmid: z.number().int().positive().optional(),
+        vmid: vmidSchema.optional(),
         section: z.enum(["options", "rules", "aliases", "ipset", "log", "refs"]).default("options"),
       },
     },
@@ -63,7 +65,7 @@ export function registerInfrastructureTools(context: ServerContext) {
       inputSchema: {
         cluster: clusterSchema,
         node: nodeSchema,
-        vmid: z.array(z.number().int().positive()).optional(),
+        vmid: z.array(vmidSchema).optional(),
         storage: z.string().optional(),
         mode: z.enum(["snapshot", "suspend", "stop"]).optional(),
         compress: z.string().optional(),
@@ -146,7 +148,7 @@ export function registerInfrastructureTools(context: ServerContext) {
         cluster: clusterSchema,
         targetKind: z.enum(["node", "qemu_vm", "lxc_container"]),
         node: z.string().optional(),
-        vmid: z.number().int().positive().optional(),
+        vmid: vmidSchema.optional(),
         scope: z.enum(["shell", "vnc"]).default("shell"),
       },
     },

--- a/src/tools/lxc/register.ts
+++ b/src/tools/lxc/register.ts
@@ -2,12 +2,13 @@ import { z } from "zod";
 import type { ServerContext } from "../../mcp-common.js";
 import { commonExecutionSchema, completedJobResult, emitProgress, jobHandleResult, settleJob, textResult } from "../../mcp-common.js";
 import type { TargetRef } from "../../types.js";
+import { createClusterSchema, createVmidSchema } from "../../tool-inputs.js";
 
 /** Registers LXC container primitives. */
 export function registerLxcTools(context: ServerContext) {
   const { server, domains, service, jobManager } = context;
-  const clusterSchema = z.string().describe("Configured cluster alias.");
-  const vmidSchema = z.number().int().positive().describe("QEMU VM or LXC CT numeric ID.");
+  const clusterSchema = createClusterSchema(context.config);
+  const vmidSchema = createVmidSchema("QEMU VM or LXC CT numeric ID.");
 
   server.registerTool("proxmox_lxc_list", { description: "List Linux containers in a cluster.", inputSchema: { cluster: clusterSchema } }, async ({ cluster }) =>
     textResult(`LXC containers for ${cluster}`, await domains.lxc.list(cluster)),

--- a/src/tools/node/register.ts
+++ b/src/tools/node/register.ts
@@ -2,11 +2,12 @@ import { z } from "zod";
 import type { ServerContext } from "../../mcp-common.js";
 import { commonExecutionSchema, completedJobResult, emitProgress, jobHandleResult, settleJob, textResult } from "../../mcp-common.js";
 import type { TargetRef } from "../../types.js";
+import { createClusterSchema, createCommandStringSchema } from "../../tool-inputs.js";
 
 /** Registers node-scoped lifecycle, status, network, and terminal primitives. */
 export function registerNodeTools(context: ServerContext) {
   const { server, domains, service, jobManager } = context;
-  const clusterSchema = z.string().describe("Configured cluster alias.");
+  const clusterSchema = createClusterSchema(context.config);
   const nodeSchema = z.string().describe("Proxmox node name.");
 
   // Uses: `/nodes` with inventory-backed capability discovery.
@@ -78,11 +79,11 @@ export function registerNodeTools(context: ServerContext) {
   server.registerTool(
     "proxmox_node_terminal_run",
     {
-      description: "Run a stateless shell command on a Proxmox node and wait for completion or a background job handle. Deferred jobs for this break-glass path are process-local to the current server.",
+      description: "Run a stateless shell command on a Proxmox node and wait for completion or a background job handle. Pass `command` as one string such as `uname -a` and choose `interpreter` separately. Deferred jobs for this break-glass path are process-local to the current server.",
       inputSchema: {
         cluster: clusterSchema,
         node: z.string().min(1).describe("Proxmox node name."),
-        command: z.string().min(1),
+        command: createCommandStringSchema("Single command string to run on the node. Example: `command: \"uname -a\", interpreter: \"bash\"`."),
         interpreter: z.enum(["sh", "bash", "powershell", "cmd"]).default("sh"),
         useSudo: z.boolean().default(false),
         ...commonExecutionSchema,

--- a/src/tools/qemu/README.md
+++ b/src/tools/qemu/README.md
@@ -38,6 +38,12 @@ Job durability boundary:
 - UPID-backed VM lifecycle and config mutations can be followed later through `job_*`
 - `proxmox_vm_guest_exec` remains process-local when deferred because the server, not Proxmox, owns that execution path
 
+Calling conventions:
+- `vmid` accepts either an integer like `100` or a digit-only string like `"100"`
+- in single-cluster deployments, callers may omit `cluster`
+- `proxmox_vm_guest_exec.command` is one command string and `interpreter` chooses the shell
+- do not pass argv arrays to `proxmox_vm_guest_exec`; use `command: "uname -a", interpreter: "bash"` instead
+
 Validation boundary:
 - keep these tools as low-level VM primitives
 - allow bounded diagnostics tools that aggregate closely related VM signals, as long as their sources and fallbacks stay explicit

--- a/src/tools/qemu/register.ts
+++ b/src/tools/qemu/register.ts
@@ -2,13 +2,14 @@ import { z } from "zod";
 import type { ServerContext } from "../../mcp-common.js";
 import { commonExecutionSchema, completedJobResult, emitProgress, jobHandleResult, settleJob, textResult } from "../../mcp-common.js";
 import type { TargetRef } from "../../types.js";
+import { createClusterSchema, createCommandStringSchema, createVmidSchema } from "../../tool-inputs.js";
 
 /** Registers QEMU VM, guest, and template primitives. */
 export function registerQemuTools(context: ServerContext) {
   const { server, domains, service, jobManager } = context;
-  const clusterSchema = z.string().describe("Configured cluster alias.");
+  const clusterSchema = createClusterSchema(context.config);
   const nodeSchema = z.string().describe("Proxmox node name.");
-  const vmidSchema = z.number().int().positive().describe("QEMU VM numeric ID.");
+  const vmidSchema = createVmidSchema("QEMU VM numeric ID.");
   const pciSlotSchema = z.number().int().nonnegative().describe("Host PCI slot index, for example `0` for `hostpci0`.");
 
   // Uses: inventory discovery for QEMU VMs.
@@ -17,7 +18,7 @@ export function registerQemuTools(context: ServerContext) {
   );
 
   // Uses: inventory discovery plus `/nodes/{node}/qemu/{vmid}/status/current` and `/nodes/{node}/qemu/{vmid}/config`.
-  server.registerTool("proxmox_vm_get", { description: "Get QEMU VM status and config.", inputSchema: { cluster: clusterSchema, vmid: vmidSchema } }, async ({ cluster, vmid }) =>
+  server.registerTool("proxmox_vm_get", { description: "Get QEMU VM status and config. `vmid` accepts either `100` or `\"100\"`.", inputSchema: { cluster: clusterSchema, vmid: vmidSchema } }, async ({ cluster, vmid }) =>
     textResult(`VM ${vmid}`, await domains.qemu.get(cluster, vmid)),
   );
 
@@ -123,11 +124,11 @@ export function registerQemuTools(context: ServerContext) {
   server.registerTool(
     "proxmox_vm_guest_exec",
     {
-      description: "Execute a command inside a QEMU VM using the guest agent or configured guest transport. Deferred jobs for this execution path are process-local to the current server.",
+      description: "Execute a command inside a QEMU VM using the guest agent or configured guest transport. `command` must be a single command string such as `uname -a`; use `interpreter` to select `bash`, `sh`, `powershell`, or `cmd`, and do not pass argv arrays. Deferred jobs for this execution path are process-local to the current server.",
       inputSchema: {
         cluster: clusterSchema,
         vmid: vmidSchema,
-        command: z.string().min(1),
+        command: createCommandStringSchema("Single command string to run inside the guest. Example: `command: \"uname -a\", interpreter: \"bash\"`."),
         interpreter: z.enum(["sh", "bash", "powershell", "cmd"]).default("sh"),
         ...commonExecutionSchema,
       },

--- a/src/tools/storage/register.ts
+++ b/src/tools/storage/register.ts
@@ -2,12 +2,14 @@ import { z } from "zod";
 import type { ServerContext } from "../../mcp-common.js";
 import { artifactResult, commonExecutionSchema, completedJobResult, emitProgress, jobHandleResult, settleJob, textResult } from "../../mcp-common.js";
 import type { TargetRef } from "../../types.js";
+import { createClusterSchema, createVmidSchema } from "../../tool-inputs.js";
 
 /** Registers storage and cloud-init snippet primitives. */
 export function registerStorageTools(context: ServerContext) {
   const { server, domains, service, jobManager, artifacts } = context;
-  const clusterSchema = z.string().describe("Configured cluster alias.");
+  const clusterSchema = createClusterSchema(context.config);
   const nodeSchema = z.string().describe("Proxmox node name.");
+  const vmidSchema = createVmidSchema("QEMU VM numeric ID.");
 
   server.registerTool("proxmox_storage_list", { description: "List storages visible to the cluster.", inputSchema: { cluster: clusterSchema } }, async ({ cluster }) =>
     textResult(`Storages for ${cluster}`, (await domains.storage.list(cluster)).data),
@@ -112,7 +114,7 @@ export function registerStorageTools(context: ServerContext) {
   server.registerTool(
     "proxmox_cloud_init_snippet_put",
     {
-      description: "Write a cloud-init snippet onto snippet-capable Proxmox storage.",
+      description: "Write a cloud-init snippet onto snippet-capable Proxmox storage. Use either inline `content` for small text or `artifactId`/`resourceUri` for artifact-backed writes.",
       inputSchema: {
         cluster: clusterSchema,
         node: z.string().optional(),
@@ -124,8 +126,9 @@ export function registerStorageTools(context: ServerContext) {
       },
     },
     async ({ cluster, node, storage, snippetPath, content, artifactId, resourceUri }, extra) => {
-      if (content === undefined && !artifactId && !resourceUri) {
-        throw new Error("Snippet write requires content, artifactId, or resourceUri");
+      const providedSources = [content !== undefined, Boolean(artifactId), Boolean(resourceUri)].filter(Boolean).length;
+      if (providedSources !== 1) {
+        throw new Error("Snippet write requires exactly one content source: inline content, artifactId, or resourceUri.");
       }
       const resolvedContent = artifactId || resourceUri ? await artifacts.readArtifactText({ artifactId, resourceUri }, service) : content!;
       return textResult(`Cloud-init snippet ${snippetPath} written`, await domains.storage.putSnippet(cluster, node, storage, snippetPath, resolvedContent, extra.signal));
@@ -155,7 +158,7 @@ export function registerStorageTools(context: ServerContext) {
       description: "Dump the generated cloud-init user, network, or meta config for a VM or template.",
       inputSchema: {
         cluster: clusterSchema,
-        vmid: z.number().int().positive(),
+        vmid: vmidSchema,
         section: z.enum(["user", "network", "meta"]).default("user"),
       },
     },

--- a/tests/tool-inputs.test.ts
+++ b/tests/tool-inputs.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { configSchema } from "../src/config.js";
+import type { RuntimeConfig } from "../src/config.js";
+import { createClusterSchema, createCommandStringSchema, createVmidSchema } from "../src/tool-inputs.js";
+
+function runtimeConfig(clusterNames: string[]): RuntimeConfig {
+  const parsed = configSchema.parse({
+    clusters: clusterNames.map((name) => ({
+      name,
+      apiUrl: `https://${name}.example:8006`,
+      auth: { type: "api_token", user: "root", realm: "pam", tokenId: "mcp", secret: "secret" },
+    })),
+  });
+
+  return {
+    ...parsed,
+    configPath: "[test]",
+    clusterMap: new Map(parsed.clusters.map((cluster) => [cluster.name, cluster])),
+    sshProfileMap: new Map(),
+    winrmProfileMap: new Map(),
+  };
+}
+
+describe("tool input schemas", () => {
+  it("defaults cluster to the only configured cluster", () => {
+    const schema = createClusterSchema(runtimeConfig(["default"]));
+    expect(schema.parse(undefined)).toBe("default");
+  });
+
+  it("requires cluster selection when multiple clusters are configured", () => {
+    const schema = createClusterSchema(runtimeConfig(["lab-a", "lab-b"]));
+    expect(() => schema.parse(undefined)).toThrow(/configured cluster aliases/);
+  });
+
+  it("accepts digit-only vmid strings", () => {
+    const schema = createVmidSchema();
+    expect(schema.parse("100")).toBe(100);
+  });
+
+  it("keeps vmid validation action-oriented", () => {
+    const schema = createVmidSchema();
+    expect(() => schema.parse("vm-100")).toThrow(/digit-only string/);
+  });
+
+  it("explains that command must be a single string", () => {
+    const schema = createCommandStringSchema("Single command string.");
+    expect(() => schema.parse(["bash", "-lc", "uname -a"])).toThrow(/single command string/);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize typed `cluster`, `vmid`, and command-string schemas for agent-facing tools
- allow single-cluster omission and digit-only `vmid` coercion while keeping validation explicit
- add operator docs/examples plus tests for the new input behavior

## Validation
- npm run check
- npm run test
- npm run build

Refs #17